### PR TITLE
Task to deprecate a CToken

### DIFF
--- a/zksync/hardhat.config.ts
+++ b/zksync/hardhat.config.ts
@@ -50,5 +50,6 @@ const config: HardhatUserConfig = {
 
 import "./tasks/addCTokenToMarket";
 import "./tasks/deployCToken";
+import "./tasks/deprecateCToken";
 
 export default config;

--- a/zksync/script/ctoken.ts
+++ b/zksync/script/ctoken.ts
@@ -103,3 +103,19 @@ export async function addCTokenToMarket(
   );
   await collateralTx.wait();
 }
+
+export async function deprecateCToken(
+  comptroller: ethers.Contract,
+  cToken: ethers.Contract
+): Promise<void> {
+  const collateralFactor: ethers.BigNumber = ethers.BigNumber.from("0");
+  const collateralTx: TransactionResponse = await comptroller._setCollateralFactor(cToken.address, collateralFactor);
+  await collateralTx.wait();
+
+  const borrowPauseTx: TransactionResponse = await comptroller._setBorrowPaused(cToken.address, true);
+  await borrowPauseTx.wait();
+
+  const reserveFactor: ethers.BigNumber = ethers.utils.parseEther("1");
+  const reserveTx: TransactionResponse = await cToken._setReserveFactor(reserveFactor);
+  await reserveTx.wait();
+}

--- a/zksync/script/types.ts
+++ b/zksync/script/types.ts
@@ -13,6 +13,10 @@ export interface AddCTokenToMarketParams {
   cToken: string;
 }
 
+export interface DeprecateCTokenParams {
+  cToken: string;
+}
+
 export interface VerifyContractParams {
   contractName: string;
   address: string;

--- a/zksync/tasks/deprecateCToken.ts
+++ b/zksync/tasks/deprecateCToken.ts
@@ -1,0 +1,62 @@
+import * as ethers from "ethers";
+import { deprecateCToken } from "../script/ctoken";
+import {
+  getMainAddresses,
+  getCTokenAddresses
+} from "../script/addresses";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { task } from "hardhat/config";
+import { getChainId } from "../script/utils";
+import { Wallet } from "zksync-web3";
+import { DeprecateCTokenParams, AddressConfig } from "../script/types";
+
+export async function main(
+  hre: HardhatRuntimeEnvironment,
+  cTokenKey: string
+): Promise<void> {
+  const wallet: Wallet = await hre.getZkWallet();
+
+  const addresses: AddressConfig = getMainAddresses();
+  const chainId: number = getChainId(hre);
+
+  const cTokens: AddressConfig = getCTokenAddresses();
+  const cTokenAddress: string = cTokens[cTokenKey][chainId];
+  const cToken: ethers.Contract = await hre.ethers.getContractAt(
+    "CToken",
+    cTokenAddress,
+    wallet
+  );
+
+  const comptrollerAddress: string = addresses["comptroller"][chainId];
+  const comptroller: ethers.Contract = await hre.ethers.getContractAt(
+    "Comptroller",
+    comptrollerAddress,
+    wallet
+  );
+
+  const isDeprecated: boolean = await comptroller.isDeprecated(cTokenAddress);
+
+  if (isDeprecated) {
+    console.log("CToken is already deprecated, exiting...");
+  } else {
+    await deprecateCToken(comptroller, cToken);
+    console.log("Deprecation completed");
+  }
+}
+
+task(
+  "deprecateCToken",
+  "Deprecate a CToken so it can no longer be used and is excluded from the pool"
+)
+  .addPositionalParam("cToken", "CToken name from zTokens.json, e.g. wbtc")
+  .setAction(
+    async (
+      { cToken }: DeprecateCTokenParams,
+      hre: HardhatRuntimeEnvironment
+    ): Promise<void> => {
+      console.log("Deprecating CToken and removing from the pool...");
+
+      await main(hre, cToken);
+    }
+  );
+


### PR DESCRIPTION
Deprecation requires multiple variables to be set to a specific value, so it is best performed programmatically to avoid user error.